### PR TITLE
Add SEO and social preview metadata; complete TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ This backlog captures practical improvements discovered from the current state o
 ## High-priority
 
 - [ ] **Extract inline `<style>` from `index.html` into `css/theme-modern.css`** to improve maintainability and reduce HTML size.
-- [ ] **Fix empty meta tags** (`description`, `author`) and add Open Graph/Twitter cards for better SEO and sharing previews.
+- [x] **Fix empty meta tags** (`description`, `author`) and add Open Graph/Twitter cards for better SEO and sharing previews.
 - [ ] **Add a Content Security Policy (CSP)** and audit inline scripts/styles that block stronger CSP settings.
 - [ ] **Create a proper build/minification step** (HTML/CSS/JS/image optimization) for production deployment.
 - [ ] **Audit JavaScript error handling** (especially image/frame preloading paths) and add graceful fallbacks for missing assets.

--- a/index.html
+++ b/index.html
@@ -8,9 +8,19 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content>
-        <meta name="author" content>
+        <meta name="description" content="Portfolio of Shivadharshan Shan Lingeswaran: software and hardware engineering projects, research, writing, and interactive demos.">
+        <meta name="author" content="Shivadharshan Shan Lingeswaran">
         <meta name="theme-color" content="#0b0e12">
+        <meta property="og:type" content="website">
+        <meta property="og:title" content="X0xRumbleLorex0X Portfolio">
+        <meta property="og:description" content="Explore software and hardware projects, research work, and creative experiments by Shivadharshan Shan Lingeswaran.">
+        <meta property="og:url" content="https://x0xrumblelorex0x.github.io/">
+        <meta property="og:image" content="https://x0xrumblelorex0x.github.io/img/ProfessionalPicture.jpg">
+        <meta property="og:image:alt" content="Portrait of Shivadharshan Shan Lingeswaran">
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:title" content="X0xRumbleLorex0X Portfolio">
+        <meta name="twitter:description" content="Software and hardware engineering portfolio featuring projects, research, and writing.">
+        <meta name="twitter:image" content="https://x0xrumblelorex0x.github.io/img/ProfessionalPicture.jpg">
 
         <title>X0xRumbleLorex0X's Portfolio</title>
 


### PR DESCRIPTION
### Motivation
- Fix previously empty `description`/`author` meta tags and add Open Graph/Twitter metadata so the site has useful SEO and richer link previews.

### Description
- Filled `meta name="description"` and `meta name="author"` in `index.html` with descriptive content for the site owner.
- Added Open Graph tags (`og:type`, `og:title`, `og:description`, `og:url`, `og:image`, `og:image:alt`) and Twitter card tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) to `index.html` for improved social previews.
- Marked the corresponding item as completed in `TODO.md` to reflect the change.

### Testing
- Ran `rg` searches (`rg -n "og:title|twitter:card|meta name=\"description\"" index.html`) to verify the new tags exist and returned expected matches, which succeeded.
- Verified no remaining empty `description`/`author` tags with `rg -n "meta name=\"(description|author)\" content(>|\s*$)" index.html`, which produced no matches for empty tags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e545c83c288329a2d36ec7f2c3585c)