### PR TITLE
Improve PDF deck resilience and landing animation performance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,9 @@
 
 ## Completed in this pass
 
+- [x] Added resilient PDF.js CDN loading with explicit error handling and safer external-link rel attributes.
+- [x] Reduced landing animation CPU usage by pausing the render loop when section/tab is not visible.
+- [x] Improved PDF failure messaging so visitors get a clear retry action when document render fails.
 - [x] Extracted inline `<style>` from `index.html` into `css/theme-modern.css`.
 - [x] Added Content Security Policy and documented current inline/script constraints.
 - [x] Added build/minification workflow (`tools/build.mjs`, npm scripts).

--- a/js/landing-event.js
+++ b/js/landing-event.js
@@ -1,12 +1,15 @@
 // Landing Event: a cursor + scroll reactive ripple in the landing section
 (function () {
-  const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const prefersReducedMotion =
+    window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const section = document.getElementById('landing-event');
   const canvas = document.getElementById('landing-canvas');
   if (!section || !canvas || prefersReducedMotion) return;
 
   const ctx = canvas.getContext('2d');
-  let w = 0, h = 0;
+  let w = 0;
+  let h = 0;
   let rafId = null;
   let active = false;
   let mouse = { x: 0, y: 0, inside: false };
@@ -19,15 +22,44 @@
     w = canvas.width = section.clientWidth;
     h = canvas.height = Math.max(220, rect.height);
   }
+
+  function stopLoop() {
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  }
+
+  function maybeStartLoop() {
+    if (active && !document.hidden && !rafId) {
+      rafId = requestAnimationFrame(loop);
+    }
+  }
+
   resize();
   window.addEventListener('resize', resize);
 
   // Track when section is visible
-  const io = new IntersectionObserver((entries) => {
-    active = entries.some(e => e.isIntersecting);
-    if (active && !rafId) rafId = requestAnimationFrame(loop);
-  }, { threshold: 0.1 });
+  const io = new IntersectionObserver(
+    (entries) => {
+      active = entries.some((e) => e.isIntersecting);
+      if (!active) {
+        stopLoop();
+        return;
+      }
+      maybeStartLoop();
+    },
+    { threshold: 0.1 }
+  );
   io.observe(section);
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stopLoop();
+      return;
+    }
+    maybeStartLoop();
+  });
 
   // Mouse
   section.addEventListener('mousemove', (e) => {
@@ -36,25 +68,41 @@
     mouse.y = e.clientY - rect.top;
     mouse.inside = true;
   });
-  section.addEventListener('mouseleave', () => { mouse.inside = false; });
+  section.addEventListener('mouseleave', () => {
+    mouse.inside = false;
+  });
 
   // Scroll impulse
-  window.addEventListener('scroll', () => {
-    const y = window.scrollY;
-    const dy = Math.abs(y - lastScrollY);
-    lastScrollY = y;
-    // Normalize and clamp
-    scrollImpulse += Math.min(40, dy * 0.15);
-  }, { passive: true });
+  window.addEventListener(
+    'scroll',
+    () => {
+      const y = window.scrollY;
+      const dy = Math.abs(y - lastScrollY);
+      lastScrollY = y;
+      // Normalize and clamp
+      scrollImpulse += Math.min(40, dy * 0.15);
+    },
+    { passive: true }
+  );
 
   function spawnRipple(x, y, strength) {
-    ripples.push({ x, y, r: 0, a: Math.min(0.6, 0.15 + strength * 0.02), w: 1.5 + Math.min(6, strength * 0.05) });
+    ripples.push({
+      x,
+      y,
+      r: 0,
+      a: Math.min(0.6, 0.15 + strength * 0.02),
+      w: 1.5 + Math.min(6, strength * 0.05),
+    });
     if (ripples.length > 40) ripples.shift();
   }
 
   function loop() {
+    if (!active || document.hidden) {
+      stopLoop();
+      return;
+    }
+
     rafId = requestAnimationFrame(loop);
-    if (!active) return;
 
     // Decay impulse
     scrollImpulse *= 0.92;
@@ -64,7 +112,14 @@
 
     // Subtle gradient background bloom centered on cursor
     if (mouse.inside) {
-      const g = ctx.createRadialGradient(mouse.x, mouse.y, 0, mouse.x, mouse.y, Math.max(w, h) * 0.5);
+      const g = ctx.createRadialGradient(
+        mouse.x,
+        mouse.y,
+        0,
+        mouse.x,
+        mouse.y,
+        Math.max(w, h) * 0.5
+      );
       g.addColorStop(0, 'rgba(124,92,255,0.10)');
       g.addColorStop(1, 'rgba(0,0,0,0)');
       ctx.fillStyle = g;
@@ -77,11 +132,14 @@
     }
 
     // Draw ripples
-    for (let i = ripples.length - 1; i >= 0; i--) {
+    for (let i = ripples.length - 1; i >= 0; i -= 1) {
       const rp = ripples[i];
       rp.r += 1.6 + rp.w * 0.25; // expand
-      rp.a *= 0.965;             // fade
-      if (rp.a < 0.015) { ripples.splice(i, 1); continue; }
+      rp.a *= 0.965; // fade
+      if (rp.a < 0.015) {
+        ripples.splice(i, 1);
+        continue;
+      }
       ctx.beginPath();
       ctx.arc(rp.x, rp.y, rp.r, 0, Math.PI * 2);
       ctx.strokeStyle = `rgba(0,212,255,${rp.a})`;
@@ -92,10 +150,15 @@
     // Cursor follower dot
     if (mouse.inside) {
       ctx.beginPath();
-      ctx.arc(mouse.x, mouse.y, 2.2 + Math.min(6, scrollImpulse * 0.08), 0, Math.PI * 2);
+      ctx.arc(
+        mouse.x,
+        mouse.y,
+        2.2 + Math.min(6, scrollImpulse * 0.08),
+        0,
+        Math.PI * 2
+      );
       ctx.fillStyle = 'rgba(255,255,255,0.8)';
       ctx.fill();
     }
   }
 })();
-

--- a/js/pdf-deck.js
+++ b/js/pdf-deck.js
@@ -3,13 +3,40 @@
   const decks = Array.from(document.querySelectorAll('.pdf-deck'));
   if (!decks.length) return;
 
+  const PDFJS_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js';
+  const PDFJS_WORKER_CDN =
+    'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+
   // Load PDF.js from CDN only once
   function ensurePdfJs() {
-    return new Promise((resolve) => {
-      if (window['pdfjsLib']) return resolve(window['pdfjsLib']);
+    return new Promise((resolve, reject) => {
+      if (window.pdfjsLib) return resolve(window.pdfjsLib);
+
+      const existing = document.querySelector('script[data-pdfjs="true"]');
+      if (existing) {
+        existing.addEventListener('load', () => resolve(window.pdfjsLib), {
+          once: true,
+        });
+        existing.addEventListener(
+          'error',
+          () => reject(new Error('Failed to load PDF.js script.')),
+          { once: true }
+        );
+        return;
+      }
+
       const s = document.createElement('script');
-      s.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js';
-      s.onload = () => resolve(window['pdfjsLib']);
+      s.src = PDFJS_CDN;
+      s.async = true;
+      s.setAttribute('data-pdfjs', 'true');
+      s.onload = () => {
+        if (!window.pdfjsLib) {
+          reject(new Error('PDF.js loaded but window.pdfjsLib is unavailable.'));
+          return;
+        }
+        resolve(window.pdfjsLib);
+      };
+      s.onerror = () => reject(new Error('Failed to load PDF.js script.'));
       document.head.appendChild(s);
     });
   }
@@ -24,8 +51,10 @@
 
     // Add CTA buttons under the deck that open pre-filled emails
     const parentSection = el.closest('section');
-    const deckTitle = (parentSection && parentSection.querySelector('h1')) ? parentSection.querySelector('h1').textContent.trim() : 'Proposal';
+    const deckHeading = parentSection && parentSection.querySelector('h1');
+    const deckTitle = deckHeading ? deckHeading.textContent.trim() : 'Proposal';
     const email = 'shan.lingeswaran@outlook.com';
+
     function mailto(label) {
       const subject = encodeURIComponent(`${label} – ${deckTitle}`);
       const lines = [
@@ -41,65 +70,77 @@
       const body = encodeURIComponent(lines.join('\n'));
       return `mailto:${email}?subject=${subject}&body=${body}`;
     }
+
     const cta = document.createElement('div');
     cta.className = 'pdf-cta';
     cta.innerHTML = `
-      <a class="btn btn-light pdf-btn" href="${mailto('Collaborate')}" target="_blank" rel="noopener">Collaborate</a>
-      <a class="btn btn-dark pdf-btn" href="${mailto('Invest Now')}" target="_blank" rel="noopener">Invest Now</a>
+      <a class="btn btn-light pdf-btn" href="${mailto('Collaborate')}" target="_blank" rel="noopener noreferrer">Collaborate</a>
+      <a class="btn btn-dark pdf-btn" href="${mailto('Invest Now')}" target="_blank" rel="noopener noreferrer">Invest Now</a>
     `;
     el.appendChild(cta);
 
-    ensurePdfJs().then((pdfjsLib) => {
-      // worker from CDN
-      pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
-      return pdfjsLib.getDocument(src).promise.then((pdf) => ({ pdf, pdfjsLib }));
-    }).then(({ pdf }) => {
-      el.classList.remove('pdf-deck--loading');
-      const total = pdf.numPages;
+    ensurePdfJs()
+      .then((pdfjsLib) => {
+        // worker from CDN
+        pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_CDN;
+        return pdfjsLib.getDocument(src).promise.then((pdf) => ({ pdf }));
+      })
+      .then(({ pdf }) => {
+        el.classList.remove('pdf-deck--loading');
+        const total = pdf.numPages;
 
-      const io = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (!entry.isIntersecting) return;
-          const holder = entry.target;
-          io.unobserve(holder);
-          const pageNum = Number(holder.getAttribute('data-page'));
-          pdf.getPage(pageNum).then((page) => {
-            const viewport = page.getViewport({ scale: 1 });
-            // Use actual container width; avoid fixed desktop minimums
-            const rawWidth = Math.floor(
-              el.clientWidth || holder.clientWidth || el.getBoundingClientRect().width || window.innerWidth || viewport.width
-            );
-            // Clamp to reasonable bounds for mobile/desktop
-            const cssWidth = Math.max(280, Math.min(rawWidth, 1600));
-            const dpr = Math.min(window.devicePixelRatio || 1, 2); // crisp but not too heavy
-            const scale = (cssWidth * dpr) / viewport.width;
-            const v = page.getViewport({ scale });
+        const io = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (!entry.isIntersecting) return;
+              const holder = entry.target;
+              io.unobserve(holder);
+              const pageNum = Number(holder.getAttribute('data-page'));
+              pdf.getPage(pageNum).then((page) => {
+                const viewport = page.getViewport({ scale: 1 });
+                // Use actual container width; avoid fixed desktop minimums
+                const rawWidth = Math.floor(
+                  el.clientWidth ||
+                    holder.clientWidth ||
+                    el.getBoundingClientRect().width ||
+                    window.innerWidth ||
+                    viewport.width
+                );
+                // Clamp to reasonable bounds for mobile/desktop
+                const cssWidth = Math.max(280, Math.min(rawWidth, 1600));
+                const dpr = Math.min(window.devicePixelRatio || 1, 2); // crisp but not too heavy
+                const scale = (cssWidth * dpr) / viewport.width;
+                const v = page.getViewport({ scale });
 
-            const canvas = document.createElement('canvas');
-            canvas.width = Math.floor(v.width);
-            canvas.height = Math.floor(v.height);
-            holder.appendChild(canvas);
-            const ctx = canvas.getContext('2d');
-            page.render({ canvasContext: ctx, viewport: v });
-            // Let CSS control responsive layout; canvas scales with container
-            canvas.style.width = '100%';
-            canvas.style.height = 'auto';
-          });
-        });
-      }, { rootMargin: '200px 0px' });
+                const canvas = document.createElement('canvas');
+                canvas.width = Math.floor(v.width);
+                canvas.height = Math.floor(v.height);
+                holder.appendChild(canvas);
+                const ctx = canvas.getContext('2d');
+                page.render({ canvasContext: ctx, viewport: v });
+                // Let CSS control responsive layout; canvas scales with container
+                canvas.style.width = '100%';
+                canvas.style.height = 'auto';
+              });
+            });
+          },
+          { rootMargin: '200px 0px' }
+        );
 
-      // Create lazy holders
-      for (let n = 1; n <= total; n++) {
-        const holder = document.createElement('div');
-        holder.className = 'pdf-page-holder';
-        holder.setAttribute('data-page', String(n));
-        pagesWrap.appendChild(holder);
-        io.observe(holder);
-      }
-    }).catch((err) => {
-      console.error('PDF load error for', src, err);
-      el.innerHTML = '<div class="pdf-error shaded-text">Unable to load PDF.</div>';
-    });
+        // Create lazy holders
+        for (let n = 1; n <= total; n += 1) {
+          const holder = document.createElement('div');
+          holder.className = 'pdf-page-holder';
+          holder.setAttribute('data-page', String(n));
+          pagesWrap.appendChild(holder);
+          io.observe(holder);
+        }
+      })
+      .catch((err) => {
+        console.error('PDF load error for', src, err);
+        el.innerHTML =
+          '<div class="pdf-error shaded-text">Unable to load PDF. Please refresh and try again.</div>';
+      });
   }
 
   decks.forEach(setupDeck);


### PR DESCRIPTION
### Motivation

- Make PDF deck rendering more robust against CDN/script load failures and provide clearer user-facing fallback messaging when PDFs fail to render. 
- Reduce CPU and battery use of the landing-section canvas effect by stopping the render loop when the section is off-screen or the tab is hidden. 
- Document these small UX/robustness fixes in the backlog so they are tracked as completed improvements.

### Description

- Hardened `js/pdf-deck.js` to load PDF.js via named CDN constants, reuse an in-flight script tag, and surface explicit load errors by returning rejected `Promise`s. 
- Assigned `pdfjsLib.GlobalWorkerOptions.workerSrc` from a constant and added a clearer fallback message (`"Unable to load PDF. Please refresh and try again."`) and safer CTA links using `rel="noopener noreferrer"`. 
- Updated `js/landing-event.js` to pause the animation loop when the landing section is not intersecting or when `document.hidden` is true, using `cancelAnimationFrame`, `visibilitychange`, and a small `maybeStartLoop`/`stopLoop` control to restart only when needed. 
- Marked the three improvements as done in `TODO.md` so the backlog reflects the delivered work.

### Testing

- Ran `npm ci` which completed successfully. 
- Ran `npm run lint` which executed successfully and reported only pre-existing warnings unrelated to the modified files. 
- Ran `npm run format:check` which failed due to an existing HTML parse/format issue in `index.html` (pre-existing repository issue). 
- Ran `npm run build` which completed and wrote output to `dist/`. 
- Ran `npm run test:smoke` which could not run end-to-end because Playwright’s browser binary was not present in the environment, and `npx playwright install chromium` failed due to the environment blocking Playwright CDN downloads (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b4bb990883298c7b4115c9fa55c6)